### PR TITLE
Modifie l'usage des cosntantes et des methodes statiques

### DIFF
--- a/AlloImage.class.php
+++ b/AlloImage.class.php
@@ -279,7 +279,7 @@
                 case 'es': case 'sensacine.com':
                 case 'fr': case 'allocine.fr':
                 case 'en': case 'screenrush.co.uk':
-                    $this->imageHost = self::$imagesUrl;
+                    $this->imageHost = ALLO_DEFAULT_URL_IMAGES;
                 break;
                 
                 default:
@@ -298,11 +298,11 @@
          * @throws ErrorException
          */
         
-        public function __construct($url = null)
+        public function __construct($url = null, $imageHost = ALLO_DEFAULT_URL_IMAGES)
         {
             if (empty($url) || !filter_var($url, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED))
             {
-                $this->imageHost = AlloHelper::$imagesUrl;
+                $this->imageHost = $imageHost;
                 $this->imagePath = self::DEFAULT_IMAGE_PATH;
                 
             }
@@ -310,12 +310,12 @@
             {
                 $urlParse = parse_url($url);
                 
-                $this->imageHost = !empty($urlParse['host']) ? $urlParse['host'] : AlloHelper::$imagesUrl;
+                $this->imageHost = !empty($urlParse['host']) ? $urlParse['host'] : $imageHost;
                 
                 if (!empty($urlParse['path']))
                     $this->imagePath = $urlParse['path'];
                 else
-                    AlloHelper::error("This isn't a URL to an image.", 7);
+                    $this->error("This isn't a URL to an image.", 7);
                 
                 // Parsage de l'URL
                 $explodePath = explode('/', $this->imagePath);
@@ -400,6 +400,27 @@
         {
             return $this->url();
         }
-        
+
+        /**
+         * Provoquer une ErrorException et/ou retourne la dernière provoquée.
+         *
+         * @param string $message=null Le message de l'erreur
+         * @param int $code=0 Le code de l'erreur
+         * @return ErrorException|null
+         */
+        public function error($message = null, $code = 0)
+        {
+            if ($message !== null)
+            {
+                $error = new ErrorException($message, $code);
+
+                AlloHelper::$_lastError = $error;
+
+                if ($this->throwExceptions)
+                    throw $error;
+            }
+
+            return AlloHelper::$_lastError;
+        }
     }
 


### PR DESCRIPTION
Je suggère ces changements pour autoriser la modification des paramètres à l’exécution. Ainsi il est plus simple de personnaliser des paramètres comme UTF8 sans toucher au fichier de constantes ce qui est le cas quand on utilise composer. Pour pouvoir correctement se baser sur les propriétés des objet j'ai du aussi changer l'usage des méthodes statiques (qui n'est de toute façon pas l'idéal, mieux vaut avoir une classe de base dont on hérite avec les méthodes utilitaire comme error) 
