### PR TITLE
fix: calcule la distance de levenstein entre la chaîne de recherche e…

### DIFF
--- a/AlloHelper.class.php
+++ b/AlloHelper.class.php
@@ -507,9 +507,11 @@
                     // Tableau contenant $cleFilm => $similitude
                     $similitudes = array();
                     
-                    // Oncalcule la distance de levenstein entre la chaîne de recherche et le titre pour chaque film
+                    // On calcule la distance de levenstein entre la chaîne de recherche et le titre/title original pour chaque film
                     foreach ($movies as $i => &$m)
-                        $similitudes[$i] = levenshtein($q, strtr(strtolower($m['title']), $accents, $normal));
+                        $similitudes[$i] = min(
+                            levenshtein($q, strtr(strtolower($m['title']), $accents, $normal)),
+                            levenshtein($q, strtr(strtolower($m['originalTitle']), $accents, $normal)));
                     
                     // On réorganise le tableau des similitudes, mais en gardant les clés.
                     asort($similitudes, true);


### PR DESCRIPTION
…t le titre et title original pour chaque film

Aujourd'hui, rechercher "Harley Quinn: Birds of Prey" renvoie "Gotham City Sirens" en 1er, et "Birds of Prey et la fantabuleuse histoire de Harley Quinn" en 2ème, car on ne calcule la distance de levenstein que sur le titre français, et pas le titre original.

En faisant le calcul sur les 2 titres et en prenant le minimum, la recherche renvoie alors le bon film en 1er.